### PR TITLE
Allow empty srcs in cue_export

### DIFF
--- a/cue/defs.bzl
+++ b/cue/defs.bzl
@@ -133,6 +133,7 @@ cue_export = rule(
         "srcs": attr.label_list(
             doc = "Source CUE files.",
             allow_files = [".cue"],
+            allow_empty = True,
         ),
         "deps": attr.label_list(
             doc = "cue_library dependencies.",

--- a/cue/defs.bzl
+++ b/cue/defs.bzl
@@ -97,6 +97,9 @@ cue_library = rule(
 )
 
 def _cue_export_impl(ctx):
+    if len(ctx.files.srcs) == 0 and len(ctx.attr.deps) == 0:
+        fail("Expected to have srcs or deps")
+
     outfile = ctx.actions.declare_file(
         ".".join((ctx.label.name, ctx.attr.filetype)),
     )
@@ -138,6 +141,7 @@ cue_export = rule(
         "deps": attr.label_list(
             doc = "cue_library dependencies.",
             providers = [CueInfo],
+            allow_empty = True,
         ),
         "filetype": attr.string(
             doc = "Output filetype.",


### PR DESCRIPTION
Allow empty srcs in cue_export so cue_dump can depend on cue_library in CMMS repo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/rules_cue/6)
<!-- Reviewable:end -->
